### PR TITLE
Bugfix/nx dependencies

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -143,7 +143,7 @@
       "projectType": "application",
       "architect": {
         "build": {
-          "builder": "@nrwl/node:build",
+          "builder": "@nrwl/node:webpack",
           "outputs": ["{options.outputPath}"],
           "options": {
             "outputPath": "dist/apps/api",
@@ -166,7 +166,7 @@
           }
         },
         "serve": {
-          "builder": "@nrwl/node:execute",
+          "builder": "@nrwl/node:node",
           "options": {
             "buildTarget": "api:build"
           }

--- a/package.json
+++ b/package.json
@@ -114,5 +114,8 @@
     "prettier": "^2.6.2",
     "ts-jest": "27.0.5",
     "typescript": "~4.4.3"
+  },
+  "resolutions": {
+    "**/node-gyp": "^7.0.0"
   }
 }


### PR DESCRIPTION
- node-sass dependencies will break on the latest Node (reference: https://github.com/sass/node-sass/issues/2877#issuecomment-644912064)
- Fixed: Unable to resolve @nrwl/node:execute (reference: https://github.com/nrwl/nx/issues/9168#issuecomment-1133329208)

NOTE: It's recommended use node 14 due to some dependencies (Tested on v16)